### PR TITLE
[sh-score] implement hack to calculate overall enabled controls instead of per standard

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "args": ["SuperAdmin@tvlk-pay-stg"],
+            "console": "integratedTerminal"
+        }
+    ]
+}


### PR DESCRIPTION
[Determining security scores](https://docs.aws.amazon.com/securityhub/latest/userguide/standards-security-score.html)

AWS SecurityHub overall score are calculated from every enabled controls in the account.
AWS SecurityHub Standard consists of specific controls. There can be more than one Standard that uses the same control.

e.g :
AWS Foundational Security Best Practices v1.0.0 consist of 249 controls
CIS AWS Foundations Benchmark v1.4.0 consist of 39 controls

This doesn't mean there's 288 control in the account because some of controls in both Standards are the same. The Security Score calculated only from 270 controls.